### PR TITLE
feat: add user registration and password login

### DIFF
--- a/item-api/internal/handler/passwordloginhandler.go
+++ b/item-api/internal/handler/passwordloginhandler.go
@@ -1,0 +1,27 @@
+package handler
+
+import (
+	"net/http"
+
+	"github.com/zeromicro/go-zero/rest/httpx"
+	"github.com/zhangxueyao/item/item-api/internal/logic"
+	"github.com/zhangxueyao/item/item-api/internal/svc"
+	"github.com/zhangxueyao/item/item-api/internal/types"
+)
+
+func PasswordLoginHandler(svcCtx *svc.ServiceContext) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		var req types.PasswordLoginReq
+		if err := httpx.Parse(r, &req); err != nil {
+			httpx.ErrorCtx(r.Context(), w, err)
+			return
+		}
+		l := logic.NewPasswordLoginLogic(r.Context(), svcCtx)
+		resp, err := l.Login(&req)
+		if err != nil {
+			httpx.ErrorCtx(r.Context(), w, err)
+		} else {
+			httpx.OkJsonCtx(r.Context(), w, resp)
+		}
+	}
+}

--- a/item-api/internal/handler/registerhandler.go
+++ b/item-api/internal/handler/registerhandler.go
@@ -1,0 +1,27 @@
+package handler
+
+import (
+	"net/http"
+
+	"github.com/zeromicro/go-zero/rest/httpx"
+	"github.com/zhangxueyao/item/item-api/internal/logic"
+	"github.com/zhangxueyao/item/item-api/internal/svc"
+	"github.com/zhangxueyao/item/item-api/internal/types"
+)
+
+func RegisterHandler(svcCtx *svc.ServiceContext) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		var req types.RegisterReq
+		if err := httpx.Parse(r, &req); err != nil {
+			httpx.ErrorCtx(r.Context(), w, err)
+			return
+		}
+		l := logic.NewRegisterLogic(r.Context(), svcCtx)
+		resp, err := l.Register(&req)
+		if err != nil {
+			httpx.ErrorCtx(r.Context(), w, err)
+		} else {
+			httpx.OkJsonCtx(r.Context(), w, resp)
+		}
+	}
+}

--- a/item-api/internal/handler/routes.go
+++ b/item-api/internal/handler/routes.go
@@ -30,6 +30,16 @@ func RegisterHandlers(server *rest.Server, serverCtx *svc.ServiceContext) {
 				Handler: LoginHandler(serverCtx),
 			},
 			{
+				Method:  http.MethodPost,
+				Path:    "/api/login/password",
+				Handler: PasswordLoginHandler(serverCtx),
+			},
+			{
+				Method:  http.MethodPost,
+				Path:    "/api/register",
+				Handler: RegisterHandler(serverCtx),
+			},
+			{
 				Method:  http.MethodGet,
 				Path:    "/api/item/:id",
 				Handler: GetItemHandler(serverCtx),

--- a/item-api/internal/logic/registerlogic.go
+++ b/item-api/internal/logic/registerlogic.go
@@ -1,0 +1,56 @@
+package logic
+
+import (
+	"context"
+	"errors"
+	"net/mail"
+	"unicode"
+
+	"github.com/zhangxueyao/item/item-api/internal/svc"
+	"github.com/zhangxueyao/item/item-api/internal/types"
+)
+
+type RegisterLogic struct {
+	ctx    context.Context
+	svcCtx *svc.ServiceContext
+}
+
+func NewRegisterLogic(ctx context.Context, svcCtx *svc.ServiceContext) *RegisterLogic {
+	return &RegisterLogic{ctx: ctx, svcCtx: svcCtx}
+}
+
+func isWeakPassword(pw string) bool {
+	if len(pw) < 8 {
+		return true
+	}
+	var hasLetter, hasDigit bool
+	for _, r := range pw {
+		if unicode.IsLetter(r) {
+			hasLetter = true
+		}
+		if unicode.IsDigit(r) {
+			hasDigit = true
+		}
+	}
+	return !(hasLetter && hasDigit)
+}
+
+func (l *RegisterLogic) Register(req *types.RegisterReq) (*types.RegisterResp, error) {
+	if _, err := mail.ParseAddress(req.Email); err != nil {
+		return nil, errors.New("invalid email")
+	}
+	if isWeakPassword(req.Password) {
+		return nil, errors.New("weak password")
+	}
+	err := l.svcCtx.UserStore.Add(svc.User{
+		Mobile:   req.Mobile,
+		Password: req.Password,
+		Email:    req.Email,
+		Age:      req.Age,
+		Gender:   req.Gender,
+	})
+	if err != nil {
+		return nil, err
+	}
+	return &types.RegisterResp{Code: 0, Msg: "success"}, nil
+}

--- a/item-api/internal/svc/servicecontext.go
+++ b/item-api/internal/svc/servicecontext.go
@@ -14,6 +14,7 @@ type ServiceContext struct {
 	ItemRpc      itemrpc.ItemClient
 	CaptchaStore *MemoryStore
 	CodeStore    *MemoryStore
+	UserStore    *UserStore
 }
 
 func NewServiceContext(c config.Config) *ServiceContext {
@@ -26,6 +27,7 @@ func NewServiceContext(c config.Config) *ServiceContext {
 		ItemRpc:      itemrpc.NewItemClient(cli.Conn()),
 		CaptchaStore: NewMemoryStore(),
 		CodeStore:    NewMemoryStore(),
+		UserStore:    NewUserStore(),
 	}
 
 	return sc

--- a/item-api/internal/svc/userstore.go
+++ b/item-api/internal/svc/userstore.go
@@ -1,0 +1,57 @@
+package svc
+
+import (
+	"errors"
+	"sync"
+)
+
+type User struct {
+	Mobile   string
+	Password string
+	Email    string
+	Age      int
+	Gender   string
+}
+
+type UserStore struct {
+	mu    sync.RWMutex
+	users map[string]User
+}
+
+func NewUserStore() *UserStore {
+	return &UserStore{users: make(map[string]User)}
+}
+
+func (s *UserStore) Add(u User) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if _, ok := s.users[u.Mobile]; ok {
+		return errors.New("user already exists")
+	}
+	s.users[u.Mobile] = u
+	return nil
+}
+
+func (s *UserStore) Get(mobile string) (User, bool) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	u, ok := s.users[mobile]
+	return u, ok
+}
+
+func (s *UserStore) Exists(mobile string) bool {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	_, ok := s.users[mobile]
+	return ok
+}
+
+func (s *UserStore) ValidatePassword(mobile, password string) bool {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	u, ok := s.users[mobile]
+	if !ok {
+		return false
+	}
+	return u.Password == password
+}

--- a/item-api/internal/types/types.go
+++ b/item-api/internal/types/types.go
@@ -43,3 +43,21 @@ type LoginResp struct {
 	Token  string `json:"token"`
 	Expire int64  `json:"expire"`
 }
+
+type RegisterReq struct {
+	Mobile   string `json:"mobile"`
+	Password string `json:"password"`
+	Email    string `json:"email"`
+	Age      int    `json:"age"`
+	Gender   string `json:"gender"`
+}
+
+type RegisterResp struct {
+	Code int    `json:"code"`
+	Msg  string `json:"msg"`
+}
+
+type PasswordLoginReq struct {
+	Mobile   string `json:"mobile"`
+	Password string `json:"password"`
+}

--- a/item-api/item.api
+++ b/item-api/item.api
@@ -41,6 +41,24 @@ type LoginResp {
         expire int64
 }
 
+type RegisterReq {
+       mobile   string
+       password string
+       email    string
+       age      int
+       gender   string
+}
+
+type RegisterResp {
+       code int
+       msg  string
+}
+
+type PasswordLoginReq {
+       mobile   string
+       password string
+}
+
 service item-api {
         @handler Captcha
         get /api/captcha returns (CaptchaResp)
@@ -50,6 +68,12 @@ service item-api {
 
         @handler Login
         post /api/login (LoginReq) returns (LoginResp)
+
+       @handler PasswordLogin
+       post /api/login/password (PasswordLoginReq) returns (LoginResp)
+
+       @handler Register
+       post /api/register (RegisterReq) returns (RegisterResp)
 
         @handler GetItem
         get /api/item/:id returns (Item)


### PR DESCRIPTION
## Summary
- add in-memory user store for managing user info
- implement registration with email and weak password validation
- support login via password and check user exists for code login

## Testing
- `go build -mod=vendor ./item-api/...`

------
https://chatgpt.com/codex/tasks/task_e_68b4429165f08326bf7997e2e9f98475